### PR TITLE
fix: fetch server height on strapi build

### DIFF
--- a/utils/redux/app/sagas.ts
+++ b/utils/redux/app/sagas.ts
@@ -37,6 +37,8 @@ import {
 import { LWManager }                    from '../LWManager';
 import { VtxconfigAuthorizeAndSetWeb3 } from 'ethvtx/lib/vtxconfig/actions/actions';
 import { RGA }                          from '../../misc/ga';
+import { fetch_height }                 from '../strapi_cache/polls';
+import { StrapiCacheSetHeight }         from '../strapi_cache/actions';
 
 /**
  * Called when the app starts. Builds Strapi and sets it in the store.
@@ -54,6 +56,8 @@ function* onAppStart(action: IStart): SagaIterator {
     let strapi;
     try {
         strapi = new Strapi(state.app.config.strapi_endpoint);
+        const server_height = yield call(fetch_height, strapi);
+        yield put(StrapiCacheSetHeight(server_height));
     } catch (e) {
         return yield put(Status(AppStatus.CannotReachServer));
     }

--- a/utils/redux/strapi_cache/polls.ts
+++ b/utils/redux/strapi_cache/polls.ts
@@ -2,12 +2,13 @@ import { VtxPollCb }                                from 'ethvtx/lib/state';
 import { AppState, StrapiCacheCallReturnFragment }  from '../app_state';
 import { Dispatch }                                 from 'redux';
 import { StrapiCacheSetData, StrapiCacheSetHeight } from './actions';
+import Strapi                                       from 'strapi-sdk-javascript';
 
-const fetch_height = async (state: AppState): Promise<number> => {
+export const fetch_height = async (strapi: Strapi): Promise<number> => {
 
-    if (!state.app.strapi) return 0;
+    if (!strapi) return 0;
 
-    const entry: { id: number; height: number; } = await state.app.strapi.getEntry('heights', '1') as any;
+    const entry: { id: number; height: number; } = await strapi.getEntry('heights', '1') as any;
     return entry.height as number;
 };
 
@@ -49,6 +50,6 @@ const data_fetcher_poll: VtxPollCb = async (state: AppState, emit: Dispatch, new
 };
 
 export const data_fetcher = {
-    interval: 3,
+    interval: 1,
     poll: data_fetcher_poll
 };


### PR DESCRIPTION
- No more wait on first poll round => fetch height immediately
- Increase local check for freshness frequency

resolves #57